### PR TITLE
#987

### DIFF
--- a/ita_install_package/ITA/ita-contents/ita-root/webroot/menus/systems/2100000309/01_browse.php
+++ b/ita_install_package/ITA/ita-contents/ita-root/webroot/menus/systems/2100000309/01_browse.php
@@ -32,10 +32,6 @@
         // browse系共通ロジックパーツ01
         require_once ( $root_dir_path . "/libs/webcommonlibs/web_parts_for_browse_01.php");
         
-        // メンテナンス可能メニューを参照のみ可能の権限ユーザが見てないか判定するパーツ
-        // (この処理は非テンプレートのコンテンツのみに必要)
-        require_once ( $root_dir_path . "/libs/webcommonlibs/web_parts_for_maintenance.php");
-
         //アクセス権を判定
         if( array_key_exists( "symphony_instance_id", $_GET ) === true ){
             // クエリからsymphony_instance_idを取得

--- a/ita_install_package/ITA/ita-contents/ita-root/webroot/menus/systems/2100020112/01_browse.php
+++ b/ita_install_package/ITA/ita-contents/ita-root/webroot/menus/systems/2100020112/01_browse.php
@@ -63,10 +63,6 @@
         // browse系共通ロジックパーツ01
         require_once ( $root_dir_path . "/libs/webcommonlibs/web_parts_for_browse_01.php");
         
-        // メンテナンス可能メニューを参照のみ可能の権限ユーザが見てないか判定するパーツ
-        // (この処理は非テンプレートのコンテンツのみに必要)
-        require_once ( $root_dir_path . "/libs/webcommonlibs/web_parts_for_maintenance.php");
-        
         // クエリ存在判定と成功時の取得
         if( !array_key_exists( "execution_no", $_GET ) ){
             // アクセスログ出力(クエリ無し警告)

--- a/ita_install_package/ITA/ita-contents/ita-root/webroot/menus/systems/2100020212/01_browse.php
+++ b/ita_install_package/ITA/ita-contents/ita-root/webroot/menus/systems/2100020212/01_browse.php
@@ -57,10 +57,6 @@
         // browse系共通ロジックパーツ01
         require_once ( $root_dir_path . "/libs/webcommonlibs/web_parts_for_browse_01.php");
         
-        // メンテナンス可能メニューを参照のみ可能の権限ユーザが見てないか判定するパーツ
-        // (この処理は非テンプレートのコンテンツのみに必要)
-        require_once ( $root_dir_path . "/libs/webcommonlibs/web_parts_for_maintenance.php");
-        
         // クエリ存在判定と成功時の取得
         if( !array_key_exists( "execution_no", $_GET ) ){
             // アクセスログ出力(クエリ無し警告)

--- a/ita_install_package/ITA/ita-contents/ita-root/webroot/menus/systems/2100020313/01_browse.php
+++ b/ita_install_package/ITA/ita-contents/ita-root/webroot/menus/systems/2100020313/01_browse.php
@@ -56,10 +56,6 @@
         // browse系共通ロジックパーツ01
         require_once ( $root_dir_path . "/libs/webcommonlibs/web_parts_for_browse_01.php");
         
-        // メンテナンス可能メニューを参照のみ可能の権限ユーザが見てないか判定するパーツ
-        // (この処理は非テンプレートのコンテンツのみに必要)
-        require_once ( $root_dir_path . "/libs/webcommonlibs/web_parts_for_maintenance.php");
-        
         // クエリ存在判定と成功時の取得
         if( !array_key_exists( "execution_no", $_GET ) ){
             // アクセスログ出力(クエリ無し警告)

--- a/ita_install_package/ITA/ita-contents/ita-root/webroot/menus/systems/2100080010/01_browse.php
+++ b/ita_install_package/ITA/ita-contents/ita-root/webroot/menus/systems/2100080010/01_browse.php
@@ -52,10 +52,6 @@
         // browse系共通ロジックパーツ01
         require_once ( $root_dir_path . "/libs/webcommonlibs/web_parts_for_browse_01.php");
         
-        // メンテナンス可能メニューを参照のみ可能の権限ユーザが見てないか判定するパーツ
-        // (この処理は非テンプレートのコンテンツのみに必要)
-        require_once ( $root_dir_path . "/libs/webcommonlibs/web_parts_for_maintenance.php");
-        
         // クエリ存在判定と成功時の取得
         if( !array_key_exists( "execution_no", $_GET ) ){
             // アクセスログ出力(クエリ無し警告)


### PR DESCRIPTION
#987	「作業状態確認」メニューのロール情報を「閲覧のみ」で設定すると表示権限が無いメニューと表示される

対象メニュー
2100020001:Ansible-Legacy:2100020112:作業状態確認
2100020002:Ansible-Pioneer:2100020212:作業状態確認
2100020003:Ansible-LegacyRole:2100020313:作業状態確認
2100080001:Terraform:2100080010:作業状態確認
2100100001:Symphony:2100000309:Symphony作業確認
2100090001:Conductor:2100180005:Conductor作業確認  　既に見えていた。