### PR TITLE
exastro-suite#1172 修正

### DIFF
--- a/ita_install_package/install_scripts/bin/ita_builder_core.sh
+++ b/ita_install_package/install_scripts/bin/ita_builder_core.sh
@@ -382,8 +382,8 @@ configure_yum_env() {
             cp -R $ITA_EXT_FILE_DIR/yum/ $LOCAL_BASE_DIR >> "$ITA_BUILDER_LOG_FILE" 2>&1
 
             yum localinstall -y --nogpgcheck ${YUM__ENV_PACKAGE} >> "$ITA_BUILDER_LOG_FILE" 2>&1
-
-            ls /etc/yum.repos.d/ita.repo >> "$ITA_BUILDER_LOG_FILE" 2>&1 | xargs grep "yum_all" >> "$ITA_BUILDER_LOG_FILE" 2>&1
+            
+            ls /etc/yum.repos.d/ita.repo 2>&1 | tee -a "$ITA_BUILDER_LOG_FILE" 2>&1 | xargs grep -s "yum_all" >> "$ITA_BUILDER_LOG_FILE" 2>&1
 
             if [ $? != 0 ]; then
                 echo "["yum_all"]

--- a/ita_install_package/install_scripts/bin/ita_builder_core.sh
+++ b/ita_install_package/install_scripts/bin/ita_builder_core.sh
@@ -382,7 +382,7 @@ configure_yum_env() {
             cp -R $ITA_EXT_FILE_DIR/yum/ $LOCAL_BASE_DIR >> "$ITA_BUILDER_LOG_FILE" 2>&1
 
             yum localinstall -y --nogpgcheck ${YUM__ENV_PACKAGE} >> "$ITA_BUILDER_LOG_FILE" 2>&1
-            
+
             ls /etc/yum.repos.d/ita.repo 2>&1 | tee -a "$ITA_BUILDER_LOG_FILE" 2>&1 | xargs grep -s "yum_all" >> "$ITA_BUILDER_LOG_FILE" 2>&1
 
             if [ $? != 0 ]; then


### PR DESCRIPTION
exastro-suite#1172 に対する修正のプルリクエストとなります。

# 修正内容
ita_builder_core.shの386行目にて、既存のコードではlsコマンドの結果をログファイルに出力した内容をgrepしていたため、
必ずgrepが失敗する挙動となっていました。

- before
```
ls /etc/yum.repos.d/ita.repo >> "$ITA_BUILDER_LOG_FILE" 2>&1 | xargs grep "yum_all" >> "$ITA_BUILDER_LOG_FILE" 2>&1
```

そのため、teeコマンドにてログと標準出力の両方に出力するようにし、grepが機能するように修正しました。
また、lsコマンドの結果をそのままgrepに渡してしまうと、スペースをデリミタとして以下のようなエラーが出力してしまうため、
-sをつけています。

```
grep: ls:: No such file or directory
grep: cannot: No such file or directory
grep: access: No such file or directory
grep: /etc/yum.repos.d/ita.repo:: No such file or directory
grep: No: No such file or directory
grep: such: No such file or directory
grep: file: No such file or directory
grep: or: No such file or directory
grep: directory: No such file or directory
```

- after
```
ls /etc/yum.repos.d/ita.repo 2>&1 | tee -a "$ITA_BUILDER_LOG_FILE" 2>&1 | xargs grep -s "yum_all" >> "$ITA_BUILDER_LOG_FILE" 2>&1
```