### PR TITLE
#1146 add "distro_mariadb" in answer file

### DIFF
--- a/ita_install_package/install_scripts/ita_answers.txt
+++ b/ita_install_package/install_scripts/ita_answers.txt
@@ -31,6 +31,12 @@ ita_language:ja_JP
 #   the RHEL7 and RHEL8 libraries, please do so in advance.
 linux_os:
 
+# Install MariaDB provided by distro or not.
+#   yes : Install MariaDB provided by distro
+#   no  : Install Official MariaDB (https://mariadb.org/)
+# Note: If "linux_os" is "CentOS7" or "RHEL7", ignore this flag and install distro's one.
+distro_mariadb:yes
+
 # Enter the MariaDB root user's password
 # e.g) db_root_password:sample_root_password
 db_root_password:


### PR DESCRIPTION
アンサーファイルにパラメータdistro_mariadbを追加。この値がyesならば、OSディストリビューションに含まれているMariaDBをインストールし、noであれば公式のMariaDB( https://mariadb.org/ )のパッケージをインストールする。ただし、CentOS7/RHEL7の場合は、distro_mariadbの値は無視されて、必ず公式のMariaDBがインストールされる。