### PR TITLE
Issue #1146 の修正で、MariaDBがインストール済みだとインストーラが途中で止まる

### DIFF
--- a/ita_install_package/ext_files_for_CentOS8.x/etc_my.cnf.d/server.cnf
+++ b/ita_install_package/ext_files_for_CentOS8.x/etc_my.cnf.d/server.cnf
@@ -64,3 +64,6 @@ character-set-server = utf8
 # use this group for options that older servers don't understand
 [mariadb-10.4]
 disable_unix_socket
+
+[mariadb-10.5]
+disable_unix_socket

--- a/ita_install_package/install_scripts/bin/ita_builder_core.sh
+++ b/ita_install_package/install_scripts/bin/ita_builder_core.sh
@@ -36,16 +36,6 @@ backup_suffix() {
 }
 
 
-service_exists() {
-    local SERVICE_NAME=$1
-    if [[ $(systemctl list-units --all -t service --full --no-legend "${SERVICE_NAME}.service" | cut -f1 -d' ') == ${SERVICE_NAME}.service ]]; then
-        return 0
-    else
-        return 1
-    fi
-}
-
-
 list_pear_package() {
     local dst_dir=$1
 
@@ -474,14 +464,23 @@ configure_mariadb() {
         mkdir -p -m 777 /var/log/mariadb >> "$ITA_BUILDER_LOG_FILE" 2>&1
     fi
 
-    # install MariaDB
-    service_exists mariadb
+    # check MariaDB is installed
+    # The command "yum list" is case insensitive, so both "mariadb-server" and "MariaDB-Server" will be matched.
+    yum list installed mariadb-server >> "$ITA_BUILDER_LOG_FILE" 2>&1
     if [ $? -ne 0 ]; then
+        log "Install and initialize MariaDB"
         install_mariadb
+        initialize_mariadb
+    else
+        log "Confirm whether root password has been changed"
+        env MYSQL_PWD="$db_root_password" mysql -uroot -e "show databases" >> "$ITA_BUILDER_LOG_FILE" 2>&1
+        if [ $? == 0 ]; then
+            log "Root password of MariaDB is already setting."
+        else
+            log "Initialize MariaDB"
+            initialize_mariadb
+        fi
     fi
-
-    # initialize MariaDB
-    initialize_mariadb
 }
 
 


### PR DESCRIPTION
MariaDBがインストール済みだと、expectの対話が噛み合わず、インストーラが途中で止まる